### PR TITLE
Fix requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 tqdm==4.30.0
 pytorch_pretrained_bert==0.5.1
+setuptools==56.1.0
 git+git://github.com/j6mes/drqa@parallel
 git+git://github.com/sheffieldnlp/fever-scorer@master
 


### PR DESCRIPTION
The current requirements include `git+git://github.com/sheffieldnlp/fever-scorer@master` that trigger the following bug https://github.com/pypa/setuptools/issues/2741 if setuptools it is not in the correct version.

This can be fixed as explained in the previous link, by using `setuptools==56.1.0`

This PR add it to the requirements of GEAR.